### PR TITLE
chore: update jekyll version

### DIFF
--- a/plainwhite.gemspec
+++ b/plainwhite.gemspec
@@ -12,8 +12,8 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r!^(assets|_layouts|_includes|_sass|LICENSE|README|404.html|sitemap.xml)!i) }
 
-  spec.add_runtime_dependency "jekyll", "~> 3.7.3"
-  spec.add_runtime_dependency "jekyll-seo-tag", "~> 2.1.0"
+  spec.add_runtime_dependency "jekyll", ">= 4.0.0"
+  spec.add_runtime_dependency "jekyll-seo-tag", "~> 2.6.1"
 
   spec.add_development_dependency "bundler", "> 1.16"
   spec.add_development_dependency "rake", "~> 12.0"


### PR DESCRIPTION
Hi I noticed that the latest version on master did not support version 4.0.0 of Jekyll, so I updated the dependencies to the latest versions.