### PR TITLE
Fix the search error when use Latex

### DIFF
--- a/search.json
+++ b/search.json
@@ -14,7 +14,7 @@ sitemap:
       "tags"     : "{{ post.tags | join: ', ' }}",
       "url"      : "{{ site.baseurl }}{{ post.url }}",
       "date"     : "{{ post.date }}",
-      "content"     : "{{ post.content | strip_html | strip_newlines | remove_chars | escape | truncate:200 }}"
+      "content"     : {{ post.content | strip_html | strip_newlines | truncate:400 | jsonify }}
     } {% unless forloop.last %},{% endunless %}
   {% endfor %}
 ]


### PR DESCRIPTION
I fixed a bug about simple-jekyll-search's config. It will occurred an error when use special characters like `$` and `\` etc. 

- **error:** `SimpleJekyllSearch --- failed to get JSON (/search.json)`

This is because special characters can cause regular expression errors and thus fail to generate search.json.

I had find the solution in <https://github.com/christian-fei/Simple-Jekyll-Search>, and it now works great with `Latex` formulas and special characters. **Because it will escape special characters**. 😊

Only changed `{ post.content | strip_html | strip_newlines | truncate:400 | jsonify }` and removed extra quotation marks~