### PR TITLE
feat: support latex

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,6 +18,7 @@ plainwhite:
   sitemap: true # set to true to generate sitemap.xml content
   search: true # set to true to enable searchbar
   dark_mode: true # set to true to add dark mode toggle
+  latex: true # set to true to enable latex
   portfolio_image: "assets/portfolio.png" # the path from the base directory of the site to the image to display (no / at the start)
   html_lang: "en" # set the lang attribute of the <html> tag for the pages. See here for a list of codes: https://www.w3schools.com/tags/ref_country_codes.asp
   condensed_mobile:

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -187,6 +187,20 @@
   <script src="{{ "/assets/js/simple-jekyll-search.min.js" | relative_url }}"></script>
   <script src="{{ "/assets/js/search.js" | relative_url }}"></script>
   {% endif %}
+
+  {% if site.plainwhite.latex %}
+  <script type="text/x-mathjax-config">
+  MathJax.Hub.Config({
+    tex2jax: {
+      inlineMath: [['$','$'], ['\\(','\\)']],
+      processEscapes: true
+    }
+  });
+  </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML"
+          type="text/javascript"></script>
+  {% endif %}
+
 </body>
 
 </html>

--- a/_posts/2019-03-23-welcome-to-jekyll.markdown
+++ b/_posts/2019-03-23-welcome-to-jekyll.markdown
@@ -21,6 +21,21 @@ rzp.capture(payment_id, cost)
 	})
 ```
 
+$$
+	Latex \space supported: A =
+	\left[
+	\begin{matrix}
+	a_{11}&a_{12}&\cdots&a_{1n}\\
+	a_{21}\\
+	\vdots&&\ddots\\
+	a_{n1}&&&a_{nn}
+	\end{matrix}
+	\right]
+	，\mathbf{w}_i^0 = \frac{(\prod_{j=1}^na_{ij})^{\frac{1}{n}}}{\sum_{i=1}^n (\prod_{j=1}^n a_{i,j})^{\frac{1}{n}}},n=1,2,\cdots,n
+$$
+
+Inline latex supported: $\mathbf{λ_{mi}}+\mathbf{λ_{max}}$
+
 Check out the [Jekyll docs][jekyll-docs] for more info on how to get the most out of Jekyll. File all bugs/feature requests at [Jekyll’s GitHub repo][jekyll-gh]. If you have questions, you can ask them on [Jekyll Talk][jekyll-talk].
 
 [jekyll-docs]: https://jekyllrb.com/docs/home

--- a/_sass/dark.scss
+++ b/_sass/dark.scss
@@ -1,8 +1,9 @@
-.dark,
+.dark {
+	background-color: #171717;
+}
 .dark * {
 	$dark_text_color: #f6f6f6;
 	$dark_link_color: #4da3ff;
-	background-color: #171717;
 	color: $dark_text_color;
 	border-color: #e6e6e6;
 


### PR DESCRIPTION
I am planning to use your repository to create my blog. I found that latex is not supported yet, so I made some modifications to support latex rendering. I hope you like it. 🏝

* You can enable or disable latex by the `_config.yml`:

```yaml
  latex: true # set to true to enable latex
```

* example (add latex math formula on the original post):

![jekyll-plainwhite-latex](https://user-images.githubusercontent.com/59989422/211180266-88e0b084-6cd6-4242-b9ed-da173cb72168.png)
