### PR TITLE
remove literal tab character from content string

### DIFF
--- a/search.json
+++ b/search.json
@@ -14,7 +14,7 @@ sitemap:
       "tags"     : "{{ post.tags | join: ', ' }}",
       "url"      : "{{ site.baseurl }}{{ post.url }}",
       "date"     : "{{ post.date }}",
-      "content"     : "{{ post.content | strip_html | strip_newlines | remove_chars | escape | truncate:200 }}"
+      "content"     : "{{ post.content | strip_html | strip_newlines | remove_chars | remove:  "	" | escape | truncate:200 }}"
     } {% unless forloop.last %},{% endunless %}
   {% endfor %}
 ]


### PR DESCRIPTION
JsonLoader doesn't allow literal tab character in json string. if content string contains literal tab character, json loader emits error "bad control character in string".